### PR TITLE
Better the focus styling for links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,6 +38,7 @@ repos:
 
 # Style Variables
 brand_color: "#FFCC3D"
+focus_color: "mediumseagreen"
 
 # Offline caching
 offline_cache: false

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -38,7 +38,7 @@ body {
     font-family: "Avenir Next", Arial, sans-serif;
     font-weight: 400;
     font-style: normal;
-    line-height: 1.466666667;
+    line-height: 1.6;
 }
 
 h1,

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -113,12 +113,6 @@ Links
 ==================================
 */
 
-a {
-    -webkit-transition: .2s;
-       -moz-transition: .2s;
-            transition: .2s;
-}
-
 a,
 a:link,
 a:visited {
@@ -140,21 +134,14 @@ a:active {
 }
 
 a:focus {
-    border-bottom: 1px solid #0072ce;
-    color: #0072ce;
-    outline: thin dotted;
+    outline: 2px solid {{ site.focus_color }};
+    outline-offset: 3px;
+    color: black;
     text-decoration: none;
 }
 
 a.title-link {
     color: #75787B;
-    border-bottom: none;
-}
-
-a.title-link:hover,
-a.title-link:active,
-a.title-link:focus {
-    color: #7eb8dd;
     border-bottom: none;
 }
 
@@ -167,7 +154,7 @@ a.skip-link {
 a.skip-link:hover,
 a.skip-link:active,
 a.skip-link:focus {
-    background-color: #0072ce;
+    background-color: {{ site.focus_color }};
     color: #fff;
     border-bottom: none;
 }
@@ -181,8 +168,6 @@ Navigation
 .sidebar-nav a {
   display: block;
   padding: 10px;
-  -webkit-transition: unset;
-  transition: unset;
 }
 .sidebar-nav a,
 .sidebar-nav a:link,


### PR DESCRIPTION
This PR goes in and fixes 2 things:

- focus styling before was really subtle: now it's clear
- more line-height for the text because otherwise it looked pretty squished

| before   | after   |
|---------------|---------------|
|  <img width="1406" alt="Screen Shot 2020-03-16 at 5 52 27 PM" src="https://user-images.githubusercontent.com/2454380/76808153-342bff80-67bd-11ea-9eeb-79c06ef6e32b.png"> | <img width="1406" alt="Screen Shot 2020-03-16 at 5 52 08 PM" src="https://user-images.githubusercontent.com/2454380/76808191-49a12980-67bd-11ea-9d4c-e00e4137e9be.png">   |


