### PR TITLE
Add lang attribute to the HTML element

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ page.lang }}">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta charset="utf-8" />

--- a/pages/_fr/fr-sub-page-one.md
+++ b/pages/_fr/fr-sub-page-one.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: fr Sub-page one
-lang: en
+lang: fr
 trans_url: Sub-page one
 ---
 


### PR DESCRIPTION
Added a `lang="en"` or `lang="fr"` attribute to the HTML element. 

Also noticed one of the sub pages had the wrong lang attribute so changed it around. 

Very small change.

| en   | fr   |
|---------------|---------------|
| <img width="1118" alt="Screen Shot 2020-03-17 at 12 40 06 PM" src="https://user-images.githubusercontent.com/2454380/76879399-91bb5d00-684c-11ea-8649-6dc8e8871b67.png"> | <img width="1118" alt="Screen Shot 2020-03-17 at 12 40 17 PM" src="https://user-images.githubusercontent.com/2454380/76879387-8ec06c80-684c-11ea-92d7-ff890692dbd4.png">  |



