### PR TITLE
Make h1 the page title + minor update for colour contrast settings

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,13 +39,13 @@
           {% if site.logourl != null %}
           <img class="logo" src="{{ site.logourl }}" alt="{{ site.logoalt }}" />
           {% endif %}
-          <h1 class="site-title">
+          <div class="site-title">
             <a
               class="title-link"
               href="{{ site.baseurl }}{{ site.data.translations[page.lang].homepage-slug }}"
               >{{site.data.translations[page.lang].site-name }}</a
             >
-          </h1>
+          </div>
           <h2 class="float-right">
             <a href="{{ site.baseurl }}/{{ page.trans_url | slugify }}"
               >{{ site.data.translations[page.lang].language }}</a

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 ---
-<h2 class="page-title">{{ page.title }}</h2>
+
+<h1 class="page-title">{{ page.title }}</h1>
 
 {{ content }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,11 +1,12 @@
 ---
 layout: default
 ---
-<article>
-    <h2 class="page-title">{{ page.title }}</h2>
-    <p class="meta">{{ page.date | date_to_string }}</p>
 
-    <div class="post">
+<article>
+  <h1 class="page-title">{{ page.title }}</h1>
+  <p class="meta">{{ page.date | date_to_string }}</p>
+
+  <div class="post">
     {{ content }}
-    </div>
+  </div>
 </article>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -13,6 +13,8 @@ Variables
 
 $brandColor: #ffcc3d;
 $focusColor: mediumseagreen;
+$lightGrey: #6f6f6f;
+$darkGrey: #424242;
 
 /*
 Normalize the box model
@@ -62,7 +64,7 @@ strong {
   font-size: 1.625em;
   font-family: "Avenir Next", Arial, sans-serif;
   font-weight: normal;
-  color: #919395;
+  color: $lightGrey;
   margin: 0;
   line-height: 1.2941176470588236;
   display: inline-block;
@@ -147,8 +149,14 @@ a:focus {
 }
 
 a.title-link {
-  color: #75787b;
+  color: $lightGrey;
   border-bottom: none;
+
+  &:hover,
+  &:active,
+  &:focus {
+    color: #424242;
+  }
 }
 
 a.skip-link {
@@ -179,7 +187,7 @@ Navigation
 .sidebar-nav a,
 .sidebar-nav a:link,
 .sidebar-nav a:visited {
-  color: #75787b;
+  color: $lightGrey;
   border-bottom: none;
 }
 
@@ -187,7 +195,7 @@ Navigation
 .sidebar-nav > ul > li a:focus,
 .sidebar-nav > ul > li a:active,
 .sidebar-nav > ul .sidebar-nav-active > a {
-  color: #75787b;
+  color: $darkGrey;
   border-left: 4px solid $brandColor;
   background-color: transparent;
   padding-left: 6px;
@@ -342,7 +350,7 @@ Style
 */
 
 .intro {
-  color: #75787b;
+  color: $lightGrey;
 }
 
 li h4 {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -82,7 +82,7 @@ h4 {
 }
 
 .page-title {
-  margin-top: 0.727272727em; /* 16/22 */
+  margin-top: 0.4em; /* 16/32 - .1 (pad it out a bit) */
 }
 
 .float-right {
@@ -222,7 +222,7 @@ Navigation
     padding-left: 30px;
     font-size: 1em;
   }
-  
+
   &:hover a,
   &:focus a,
   &:active a {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -15,6 +15,8 @@ $brandColor: #ffcc3d;
 $focusColor: mediumseagreen;
 $lightGrey: #6f6f6f;
 $darkGrey: #424242;
+$blue: #0068bc;
+$darkBlue: #005295;
 
 /*
 Normalize the box model
@@ -124,20 +126,15 @@ Links
 a,
 a:link,
 a:visited {
-  color: #0072ce;
-  border-bottom: 1px dotted #0072ce;
+  color: $blue;
+  border-bottom: 1px dotted $blue;
   text-decoration: none;
 }
 
-a:hover {
-  border-bottom: 1px solid #7eb8dd;
-  color: #7eb8dd;
-  text-decoration: none;
-}
-
+a:hover,
 a:active {
-  border-bottom: 1px solid #002d72;
-  color: #002d72;
+  border-bottom: 1px solid $darkBlue;
+  color: $darkBlue;
   text-decoration: none;
 }
 
@@ -160,7 +157,6 @@ a.title-link {
 }
 
 a.skip-link {
-  color: #0072ce;
   border-bottom: none;
   padding: 0.25em;
 }


### PR DESCRIPTION
There's a few changes in this PR

- the logo text is just a div now, not an H1
- page titles are H1s now
- colour contrast issues have been fixed (very subtly)
  - blues links and grey links are slightly darker, but not so's you'd notice
- hover states are darker rather than lighter
  - a11y deep cuts are like "what happens when you're hovering": so made the hover styles darken rather than lighten

**Note: The H1 page title is really dramatic now. I didn't change the h1 styling at all. For now, we have all the default styling and we can deal with that in a later PR.** 

Used https://color.review/ to do colour stuff. It's pretty good for that.

## Screenshots

| before | after |
|--------|-------|
| the page title is an h2, hovering the link (Canada Revenue Agency) makes it lighter        |   the page title is an h1, hovering the link (Canada Revenue Agency) makes it darker   |
|  <img width="1391" alt="Screen Shot 2020-03-18 at 3 46 50 PM" src="https://user-images.githubusercontent.com/2454380/77002648-395e8b00-6932-11ea-8e2b-7e348fe93a74.png">   |  <img width="1391" alt="Screen Shot 2020-03-18 at 3 47 01 PM" src="https://user-images.githubusercontent.com/2454380/77002642-35cb0400-6932-11ea-9e62-2a1c779876ff.png">  |

