### PR TITLE
remove google analytics

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,21 +16,6 @@
       <script src="{{ site.baseurl }}/assets/js/respond.min.js"></script>
     <![endif]-->
     <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
-
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=UA-102484926-9"
-    ></script>
-    <script>
-      window.dataLayer = window.dataLayer || []
-      function gtag() {
-        dataLayer.push(arguments)
-      }
-      gtag("js", new Date())
-
-      gtag("config", "UA-102484926-11", { anonymize_ip: true })
-    </script>
   </head>
   <body>
     <div class="container">


### PR DESCRIPTION
We had a google analytics script which was causing an error in our console (because adblock was blocking it). We're not using it anyways, so may as well toss it out.