### PR TITLE
 Remove redundant HTML role attributes

### DIFF
--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -7,7 +7,7 @@ en:
   contribute: "Contribute to this documentation"
   repo: "Repository"
   language: "Français"
-  homepage-slug: "/welcome/"
+  homepage-slug: "/information-about-file-taxes-to-access-benefits/"
   site-name: "Claim tax benefits documentation"
 fr:
   homepage-tag-line: "(fr) Help low-income Canadians file taxes to access their benefits"

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,7 +1,7 @@
 <aside>
   <p class="intro">{{ site.data.translations[page.lang].homepage-tag-line }}</p>
   <a class="skip-link visuallyhidden focusable" href="#main">Skip to Main Content</a>
-  <nav class="sidebar-nav" role="navigation">
+  <nav class="sidebar-nav">
     <ul>
       {% for navPage in site.menu %}
         {% for item in navPage.menuItems %}

--- a/_includes/welcome.md
+++ b/_includes/welcome.md
@@ -2,4 +2,4 @@
 
 The service includes both online and paper channels. Both channels are under development and cannot be used to file taxes at this time.
 
-[While the online repository is no longer actively maintained](https://github.com/cds-snc/cra-claim-tax-benefits/blob/master/docs/CONTINUING-DEVELOPMENT.md)**,** the code is open source and in the public domain — all are free to clone and use it.
+[While the online repository is no longer actively maintained](/continuing-development/)**,** the code is open source and in the public domain — all are free to clone and use it.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,7 @@
   </head>
   <body>
     <div class="container">
-      <header role="banner">
+      <header>
         <div class="wrap">
           {% if site.logourl != null %}
           <img class="logo" src="{{ site.logourl }}" alt="{{ site.logoalt }}" />
@@ -48,7 +48,7 @@
       </div>
       <!-- /.wrap content -->
 
-      <footer role="contentinfo">
+      <footer>
         <div class="wrap">
           <p>
             {{site.data.translations[page.lang].built-by}}

--- a/pages/_en/information-about-file-taxes-to-access-benefits.md
+++ b/pages/_en/information-about-file-taxes-to-access-benefits.md
@@ -9,4 +9,4 @@ trans_url: Accueil
 
 The service includes both online and paper channels. Both channels are under development and cannot be used to file taxes at this time.
 
-[While the online repository is no longer actively maintained](https://github.com/cds-snc/cra-claim-tax-benefits/blob/master/docs/CONTINUING-DEVELOPMENT.md)**,** the code is open source and in the public domain — all are free to clone and use it.
+[While the online repository is no longer actively maintained](/continuing-development/)**,** the code is open source and in the public domain — all are free to clone and use it.


### PR DESCRIPTION
Ran a few pages through an HTML validator and it looks like we're
fine except that we have a few stray "role" attributes here and there.

The warning message I'm seeing is:

> The banner role is unnecessary for element header.

and then etc for the other roles.

Removing them because it looks like we don't need 'em.

***

Also changing up some links so they point to the correct places.