### PR TITLE
Header + menu mobile fixes

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -63,14 +63,13 @@ strong {
 }
 
 .site-title {
-  font-size: 1.625em;
+  font-size: 1.33em;
   font-family: "Avenir Next", Arial, sans-serif;
   font-weight: normal;
   color: $lightGrey;
   margin: 0;
+  margin-bottom: 0.5em;
   line-height: 1.2941176470588236;
-  display: inline-block;
-  width: 70%;
 }
 
 h2 {
@@ -90,10 +89,8 @@ h4 {
 }
 
 .float-right {
-  display: inline-block;
-  width: 25%;
+  font-size: 1em;
   margin: 0;
-  text-align: right;
 }
 
 /*
@@ -468,7 +465,7 @@ Desktop Styles
 ==================================
 */
 
-@media screen and (min-width: 45em) and (min-height: 32.5em) {
+@media screen and (min-width: 45em) {
   /*
     Typography
     ==============================
@@ -478,6 +475,21 @@ Desktop Styles
     Layout
     ==============================
     */
+
+  .site-title {
+    font-size: 1.625em;
+    line-height: 1.2941176470588236;
+    display: inline-block;
+    margin-bottom: 0;
+    width: 70%;
+  }
+
+  .float-right {
+    font-size: 1.375em;
+    display: inline-block;
+    width: 25%;
+    text-align: right;
+  }
 
   .logo {
     max-width: 30%;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -185,11 +185,14 @@ Navigation
 ==================================
 */
 
+.sidebar-nav {
+  margin-left: -4px;
+}
 .sidebar-nav a {
   display: block;
-  padding: 10px;
+  padding: 0.5em;
+  padding-left: 0;
   border-left: 4px solid transparent;
-  font-size: 1.125em;
 }
 .sidebar-nav a,
 .sidebar-nav a:link,
@@ -227,7 +230,10 @@ Navigation
   list-style: none;
   border-bottom: 1px solid #babbbd;
 }
-.sidebar-nav li:last-child {
+.sidebar-nav li:first-child {
+  border-top: 1px solid #babbbd;
+}
+.sidebar-nav ul ul li:last-child {
   border-bottom: none;
 }
 
@@ -360,6 +366,7 @@ Style
 
 .intro {
   color: $lightGrey;
+  display: none;
 }
 
 li h4 {
@@ -501,6 +508,18 @@ Desktop Styles
     width: 30%;
     float: left;
     margin-bottom: 5%;
+
+    .intro {
+      display: block;
+    }
+  }
+
+  .sidebar-nav a {
+    font-size: 1.1em;
+  }
+
+  .sidebar-nav li:first-child {
+    border-top: none;
   }
 
   .main-content {


### PR DESCRIPTION
### Site header smaller on mobile
Also left-justified.

### The menu looks less bad on mobile

A few changes in here:

- made the nav links a bit smaller on desktop
- hide the aside intro on mobile
- add a border to the top nav link on mobile
- add a border to the bottom nav link all the time
- make the nav links regular size on mobile
- left-justify the nav links on mobile

## Screenshots

### mobile (more dramatic)

| before | after |
|--------|-------|
|  <img width="612" alt="Screen Shot 2020-03-20 at 3 54 30 PM" src="https://user-images.githubusercontent.com/2454380/77201801-84f46e80-6ac3-11ea-87f8-4de6f43277a6.png">  |  <img width="612" alt="Screen Shot 2020-03-20 at 3 54 35 PM" src="https://user-images.githubusercontent.com/2454380/77201794-832aab00-6ac3-11ea-9c5e-7c7e3c1f624c.png">    |

### desktop (the menu links are smaller)

| before | after |
|--------|-------|
|   <img width="1395" alt="Screen Shot 2020-03-20 at 3 54 21 PM" src="https://user-images.githubusercontent.com/2454380/77201804-86259b80-6ac3-11ea-8a47-d70c371d759c.png"> |   <img width="1395" alt="Screen Shot 2020-03-20 at 3 54 18 PM" src="https://user-images.githubusercontent.com/2454380/77201788-7f972400-6ac3-11ea-9f96-4877963fbc09.png">   |


