### PR TITLE
Add some word breaks to the continuing docs page

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -387,9 +387,13 @@ pre {
   padding: 10px;
 }
 
+table {
+  font-size: 0.8em;
+}
+
 td,
 th {
-  border: 1px solid $darkGrey;
+  border: 1px solid $lightGrey;
   padding: 0.5em;
 
   ul,
@@ -528,15 +532,9 @@ Desktop Styles
     margin-bottom: 120px;
   }
 
-  /*
-    Navigation
-    ==============================
-    */
-
-  /*
-    Style
-    ==============================
-    */
+  table {
+    font-size: 1em;
+  }
 
   /*
     Repo list

--- a/pages/_en/continuing-development.md
+++ b/pages/_en/continuing-development.md
@@ -23,7 +23,7 @@ All you need to do here is run the app and then find all the URLs.
 1. First, get it to boot up.
    - Check out "[Build and run](https://github.com/cds-snc/cra-claim-tax-benefits#build-and-run)" in the README.
    - The app will be running at [http://localhost:3005/](http://localhost:3005/).
-2. A full list of URLs can be found in [`/config/routes.config.js`](https://github.com/cds-snc/cra-claim-tax-benefits/blob/master/config/routes.config.js). They're pretty much in order, so you can see them all sequentially.
+2. A full list of URLs can be found in [`/config`<wbr>`/routes.config.js`](https://github.com/cds-snc/cra-claim-tax-benefits/blob/master/config/routes.config.js). They're pretty much in order, so you can see them all sequentially.
 
 All good! Get yerself pizza. <span role="img" aria-label="pizza slice">🍕</span>
 
@@ -43,23 +43,23 @@ Hooray! Welcome to the hippest app in gov!! To pick up development after some ar
 
 ### Repository structure
 
-| Folder               | Purpose                                                                                          |
-| -------------------- | ------------------------------------------------------------------------------------------------ |
-| `/.github/workflows` | CI/CD pipelines/workflows                                                                        |
-| `/api`               | Domain model (check out `user.json`)                                                             |
-| `/bin`               | Runtime script for Node.js                                                                       |
-| `/config`            | Configurations for the npm modules/middleware used                                               |
-| `/cypress`           | End to end test fixtures and integrations                                                        |
-| `/db`                | Conceptually, this is our cloud DB with access codes                                             |
-| `/docs`              | Technical documentation                                                                          |
-| `/locales`           | Internationalization (i18n) keys to support both English and French official languages           |
-| `/public`            | Static resources (images, scripts, stylesheets, favicon): all our styling is in `/public/scss`.  |
-| `/routes`            | Controllers (routes and business logic) and unit tests                                           |
-| `/schemas`           | Schemas for form validation for our POST routes                                                  |
-| `/scripts`           | Azure and HashiCorp Terraform scripts for Infrastructure as Code (IaC)                           |
-| `/utils`             | Utility functions and [express middleware](https://expressjs.com/en/guide/using-middleware.html) |
-| `/views`             | [Pug](https://pugjs.org/api/getting-started.html) view files that translate to HMTL at runtime   |
-| `/xml_output`        | Very early attempt at a NETFILE XML template                                                     |
+| Folder                      | Purpose                                                                                          |
+| --------------------------- | ------------------------------------------------------------------------------------------------ |
+| `/.github`<wbr>`/workflows` | CI/CD pipelines<wbr>/workflows                                                                   |
+| `/api`                      | Domain model (check out `user.json`)                                                             |
+| `/bin`                      | Runtime script for Node.js                                                                       |
+| `/config`                   | Configurations for the npm modules<wbr>/middleware used                                          |
+| `/cypress`                  | End to end test fixtures and integrations                                                        |
+| `/db`                       | Conceptually, this is our cloud DB with access codes                                             |
+| `/docs`                     | Technical documentation                                                                          |
+| `/locales`                  | Internationalization (i18n) keys to support both English and French official languages           |
+| `/public`                   | Static resources (images, scripts, stylesheets, favicon): all our styling is in `/public/scss`.  |
+| `/routes`                   | Controllers (routes and business logic) and unit tests                                           |
+| `/schemas`                  | Schemas for form validation for our POST routes                                                  |
+| `/scripts`                  | Azure and HashiCorp Terraform scripts for Infrastructure as Code (IaC)                           |
+| `/utils`                    | Utility functions and [express middleware](https://expressjs.com/en/guide/using-middleware.html) |
+| `/views`                    | [Pug](https://pugjs.org/api/getting-started.html) view files that translate to HMTL at runtime   |
+| `/xml_output`               | Very early attempt at a NETFILE XML template                                                     |
 
 ### Technology Choices
 

--- a/pages/_fr/continuer-le-développement.md
+++ b/pages/_fr/continuer-le-développement.md
@@ -23,7 +23,7 @@ Tout ce dont vous devez faire est de déployer l'application et trouver toutes l
 1. Premièrement, déployez l'application.
    - Consultez la page "[Construire et déployer](https://github.com/cds-snc/cra-claim-tax-benefits#build-and-run)" dans le `README`.
    - L'application sera disponible à l'adresse [http://localhost:3005/](http://localhost:3005/).
-2. Une liste complète des adresses est disponible dans le fichier [`/config/routes.config.js`](https://github.com/cds-snc/cra-claim-tax-benefits/blob/master/config/routes.config.js). L'ordre des adresses correspond à l'ordre d'exécution logique dans l'application.
+2. Une liste complète des adresses est disponible dans le fichier [`/config`<wbr>`/routes.config.js`](https://github.com/cds-snc/cra-claim-tax-benefits/blob/master/config/routes.config.js). L'ordre des adresses correspond à l'ordre d'exécution logique dans l'application.
 
 Tout est bon! Allez vous chercher de la pizza. <span role="img" aria-label="pizza slice">🍕</span>
 
@@ -43,23 +43,23 @@ Houra! Bienvenue dans l'application la plus branchée du Gouvernement!! Pour pou
 
 ### Structure du _repository_
 
-| Répertoire           | Usage                                                                                                                  |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `/.github/workflows` | Pipelines d'intégration et livraison continue                                                                          |
-| `/api`               | Modèle (voir `user.json`)                                                                                              |
-| `/bin`               | Script d'exécution pour Node.js                                                                                        |
-| `/config`            | Configurations des modules / middleware npm utilisés                                                                   |
-| `/cypress`           | Tests et intégrations de bout en bout                                                                                  |
-| `/db`                | Conceptuellement, il s'agit de notre base de données cloud avec des codes d'accès                                      |
-| `/docs`              | Documentation technique                                                                                                |
-| `/locales`           | Fichiers de traductions pour les langues officielles (français et anglais)                                             |
-| `/public`            | Ressources statiques (images, scripts, feuilles de styles, icône de favori): tous les styles sont sous `/public/scss`. |
-| `/routes`            | Controlleurs (routes and logique métier) et tests unitaires                                                            |
-| `/schemas`           | Schémas pour la validation des soumissons de formulaires (`HTTP POST`)                                                 |
-| `/scripts`           | Scripts Azure et HashiCorp Terraform scripts pour _Infrastructure as Code (IaC)_                                       |
-| `/utils`             | Fonctions utilitaires et [middleware express](https://expressjs.com/en/guide/using-middleware.html)                    |
-| `/views`             | Fichiers de vue [Pug](https://pugjs.org/api/getting-started.html) qui se transpose en HMTL à l'exécution               |
-| `/xml_output`        | Tentative très précoce d'un modèle XML IMPÔTNET                                                                        |
+| Répertoire                  | Usage                                                                                                                  |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `/.github`<wbr>`/workflows` | Pipelines d'intégration et livraison continue                                                                          |
+| `/api`                      | Modèle (voir `user.json`)                                                                                              |
+| `/bin`                      | Script d'exécution pour Node.js                                                                                        |
+| `/config`                   | Configurations des modules / middleware npm utilisés                                                                   |
+| `/cypress`                  | Tests et intégrations de bout en bout                                                                                  |
+| `/db`                       | Conceptuellement, il s'agit de notre base de données cloud avec des codes d'accès                                      |
+| `/docs`                     | Documentation technique                                                                                                |
+| `/locales`                  | Fichiers de traductions pour les langues officielles (français et anglais)                                             |
+| `/public`                   | Ressources statiques (images, scripts, feuilles de styles, icône de favori): tous les styles sont sous `/public/scss`. |
+| `/routes`                   | Controlleurs (routes and logique métier) et tests unitaires                                                            |
+| `/schemas`                  | Schémas pour la validation des soumissons de formulaires (`HTTP POST`)                                                 |
+| `/scripts`                  | Scripts Azure et HashiCorp Terraform scripts pour _Infrastructure as Code (IaC)_                                       |
+| `/utils`                    | Fonctions utilitaires et [middleware express](https://expressjs.com/en/guide/using-middleware.html)                    |
+| `/views`                    | Fichiers de vue [Pug](https://pugjs.org/api/getting-started.html) qui se transpose en HMTL à l'exécution               |
+| `/xml_output`               | Tentative très précoce d'un modèle XML IMPÔTNET                                                                        |
 
 ### Choix technologiques
 


### PR DESCRIPTION
Also make text inside tables smaller on mobile.

Some of the content on the continuing docs page (en and fr) was pushing
the layout off of very small screens.

The reason was that we had some long-ish filenames without any linebreaks
between them. Added some line breaks and made text in tables smaller
so that the content all fits on the screen.

## Screenshots 

### Site title was pushed off the screen

| before | after |
|--------|-------|
| <img width="1192" alt="Screen Shot 2020-03-23 at 10 24 22 AM" src="https://user-images.githubusercontent.com/2454380/77335224-43023d00-6cfc-11ea-8439-6c6f0f73b6d5.png">     |  <img width="1192" alt="Screen Shot 2020-03-23 at 10 24 25 AM" src="https://user-images.githubusercontent.com/2454380/77335234-4695c400-6cfc-11ea-882f-4f2407f7feb5.png">  |

### table was pushing content off the screen

| before | after |
|--------|-------|
| <img width="1192" alt="Screen Shot 2020-03-23 at 10 24 53 AM" src="https://user-images.githubusercontent.com/2454380/77335243-485f8780-6cfc-11ea-968d-ceb954850d0c.png">   |  <img width="1192" alt="Screen Shot 2020-03-23 at 10 24 57 AM" src="https://user-images.githubusercontent.com/2454380/77335250-4990b480-6cfc-11ea-957c-16b898af4362.png">    |




