### PR TITLE
Fix the little "repository" widget for mobile

### DIFF
--- a/_includes/repositories.html
+++ b/_includes/repositories.html
@@ -1,16 +1,20 @@
 <section id="repositories">
-    <h2>{{site.data.translations[page.lang].repo}}</h2>
-    <ul class="repo-list group">
-      <li class="list-icon">
-        <img src="https://raw.githubusercontent.com/cds-snc/find-benefits-and-services-documentation/master/assets/img/octocat.png" width="25px" alt="">
-      </li>
-      {% for repo in site.data.repos[page.lang] %}
-        <li>
-          <a href="{{ repo.url }}">
-            <h4>{{ repo.name }}</h4>
-            <p>{{ repo.description }}</p>
-          </a>
-        </li>
-      {% endfor %}
-    </ul>
-  </section>
+  <h2>{{site.data.translations[page.lang].repo}}</h2>
+  <ul class="repo-list group">
+    <li class="list-icon" aria-hidden="true">
+      <img
+        src="https://raw.githubusercontent.com/cds-snc/find-benefits-and-services-documentation/master/assets/img/octocat.png"
+        width="25px"
+        alt=""
+      />
+    </li>
+    {% for repo in site.data.repos[page.lang] %}
+    <li>
+      <a href="{{ repo.url }}">
+        <h4>{{ repo.name }}</h4>
+        <p>{{ repo.description }}</p>
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+</section>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -432,10 +432,41 @@ Repo list
 ul.repo-list {
   margin: 0.5em 0 1em 0;
   padding: 0;
+  display: flex;
 }
 
 .repo-list li {
   list-style: none;
+  display: block;
+  float: left;
+  background-color: #e7e7e6;
+  border-left: 1px solid #babbbd;
+  width: 80%;
+  max-width: 240px;
+
+  &:first-child {
+    text-align: center;
+    border-left: none;
+    line-height: 60px;
+    padding: 0.625em 1em;
+    width: 20%;
+    max-width: 70px;
+  }
+}
+
+.repo-list a {
+  &:link,
+  &:visited {
+    display: block;
+    background-color: #e7e7e6;
+    border-bottom: none;
+    padding: 0.625em 1em 1em 1em;
+  }
+
+  &:hover {
+    color: #4d5f87;
+    background-color: #cde3f1;
+  }
 }
 
 .repo-list p {
@@ -446,11 +477,6 @@ ul.repo-list {
 .repo-list h4 {
   text-transform: none;
 }
-
-/*
-Helper Classes
-==================================
-*/
 
 /*
 Clearfix list
@@ -536,56 +562,12 @@ Desktop Styles
     font-size: 1em;
   }
 
-  /*
-    Repo list
-    ------------------------------
-    */
-
   .repo-list li {
-    list-style: none;
-    display: block;
-    float: left;
-    height: 4.0625em;
-    max-height: 4.0625em;
-    background-color: #e7e7e6;
-    border-left: 1px solid #babbbd;
-    width: 30%;
-  }
+    width: 35%;
 
-  .repo-list a:link,
-  .repo-list a:visited {
-    display: block;
-    max-height: 4.0625em;
-    background-color: #e7e7e6;
-    border-bottom: none;
-    padding: 0.625em 1em 1em 1em;
-  }
-
-  .repo-list a:hover {
-    color: #4d5f87;
-    background-color: #cde3f1;
-  }
-
-  .repo-list li:first-child {
-    text-align: center;
-    border-left: none;
-    line-height: 60px;
-    padding: 0.625em 1em;
-    width: 10%;
-  }
-}
-
-@media screen and (max-width: 54.375em) and (min-height: 32.5em) {
-  /* keep the repo list containers the same height, but account for the need for more height */
-
-  .repo-list li {
-    height: 6em;
-    max-height: 6em;
-  }
-
-  .repo-list a:link,
-  .repo-list a:visited {
-    max-height: 6em;
+    &:first-child {
+      width: 10%;
+    }
   }
 }
 


### PR DESCRIPTION
CSS fix for the little "repository" widget.

Previously, it would completely break on mobile. Now it looks pretty okay.

## Screenshots

## tablet view

| before | after |
|--------|-------|
| <img width="1031" alt="Screen Shot 2020-03-23 at 4 42 06 PM" src="https://user-images.githubusercontent.com/2454380/77361437-a785c200-6d25-11ea-88fe-388f0406ea22.png">  |  <img width="1031" alt="Screen Shot 2020-03-23 at 4 42 08 PM" src="https://user-images.githubusercontent.com/2454380/77361435-a6549500-6d25-11ea-9487-25e211a7f8eb.png">    |

## mobile view 

| before | after |
|--------|-------|
| <img width="612" alt="Screen Shot 2020-03-23 at 4 42 43 PM" src="https://user-images.githubusercontent.com/2454380/77361434-a5bbfe80-6d25-11ea-8737-31f9fdeb1188.png">   |   <img width="612" alt="Screen Shot 2020-03-23 at 4 42 45 PM" src="https://user-images.githubusercontent.com/2454380/77361427-a2c10e00-6d25-11ea-9d74-2c15d79a58a0.png">  |

